### PR TITLE
Update eslint config to disallow implicit depencencies

### DIFF
--- a/reusable-configurations/.eslintrc.js
+++ b/reusable-configurations/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     'eslint-config-prettier'
   ],
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint', 'eslint-plugin-jest'],
+  plugins: ['@typescript-eslint', 'eslint-plugin-node', 'eslint-plugin-jest'],
   rules: {
     '@typescript-eslint/no-require-imports': 'error',
     '@typescript-eslint/no-non-null-assertion': 'off',
@@ -28,7 +28,8 @@ module.exports = {
       }
     ],
     'no-control-regex': 'off',
-    'no-constant-condition': ['error', {checkLoops: false}]
+    'no-constant-condition': ['error', {checkLoops: false}],
+    'node/no-extraneous-import': 'error'
   },
   overrides: [
     {


### PR DESCRIPTION
Added ESLint rule that disallows implicit dependencies (dependencies that are not specified in package.json). The motivation for that is that this is very unsafe because implicit dependencies rely on installed global packages and dependencies installed for other specified dependencies. If needed dependency is not installed locally or some of packages stops using it as dependency, it will fail to resolve. It takes whichever version is already installed and doesn't take even major versions into account.